### PR TITLE
Avoid enum for on win

### DIFF
--- a/lib/restclient/utils.rb
+++ b/lib/restclient/utils.rb
@@ -38,7 +38,7 @@ module RestClient
     # @private
     #
     def self._cgi_parseparam(s)
-      return enum_for(__method__, s) unless block_given?
+      parts = []
 
       while s[0] == ';'
         s = s[1..-1]
@@ -52,10 +52,11 @@ module RestClient
           ends = s.length
         end
         f = s[0...ends]
-        yield f.strip
+        parts.push f.strip
         s = s[ends..-1]
       end
-      nil
+
+      parts
     end
 
     # Parse a Content-Type like header.
@@ -72,11 +73,10 @@ module RestClient
     #
     def self.cgi_parse_header(line)
       parts = _cgi_parseparam(';' + line)
-      key = parts.next
+      key = parts.shift
       pdict = {}
 
-      begin
-        while (p = parts.next)
+        parts.each do |p|
           i = p.index('=')
           if i
             name = p[0...i].strip.downcase
@@ -88,8 +88,6 @@ module RestClient
             pdict[name] = value
           end
         end
-      rescue StopIteration
-      end
 
       [key, pdict]
     end

--- a/lib/restclient/utils.rb
+++ b/lib/restclient/utils.rb
@@ -76,18 +76,18 @@ module RestClient
       key = parts.shift
       pdict = {}
 
-        parts.each do |p|
-          i = p.index('=')
-          if i
-            name = p[0...i].strip.downcase
-            value = p[i+1..-1].strip
-            if value.length >= 2 && value[0] == '"' && value[-1] == '"'
-              value = value[1...-1]
-              value = value.gsub('\\\\', '\\').gsub('\\"', '"')
-            end
-            pdict[name] = value
+      parts.each do |p|
+        i = p.index('=')
+        if i
+          name = p[0...i].strip.downcase
+          value = p[i+1..-1].strip
+          if value.length >= 2 && value[0] == '"' && value[-1] == '"'
+            value = value[1...-1]
+            value = value.gsub('\\\\', '\\').gsub('\\"', '"')
           end
+          pdict[name] = value
         end
+      end
 
       [key, pdict]
     end

--- a/spec/integration/request_spec.rb
+++ b/spec/integration/request_spec.rb
@@ -13,7 +13,7 @@ describe RestClient::Request do
     it "is successful with the correct ca_file" do
       request = RestClient::Request.new(
         :method => :get,
-        :url => 'https://www.mozilla.org',
+        :url => 'https://ev-root.chain-demos.digicert.com',
         :ssl_ca_file => File.join(File.dirname(__FILE__), "certs", "digicert.crt")
       )
       expect { request.execute }.to_not raise_error
@@ -22,7 +22,7 @@ describe RestClient::Request do
     it "is successful with the correct ca_path" do
       request = RestClient::Request.new(
         :method => :get,
-        :url => 'https://www.mozilla.org',
+        :url => 'https://ev-root.chain-demos.digicert.com',
         :ssl_ca_path => File.join(File.dirname(__FILE__), "capath_digicert")
       )
       expect { request.execute }.to_not raise_error


### PR DESCRIPTION
Change response header parsing from iterator to iteration to avoid the Win bug on Ruby 2.5

# Testing
- [ ] **verify** `rake spec` passing
- [ ] **verify** an actual request works
